### PR TITLE
Fixes issue where the repository name is different from the framework

### DIFF
--- a/RomeBuild.xcodeproj/project.pbxproj
+++ b/RomeBuild.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		054C97811D549B3B00C481BD /* TaskStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054C97801D549B3B00C481BD /* TaskStatus.swift */; };
 		056D13DE1CEF5C55002FF045 /* Progress.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 056D13DB1CEF58B2002FF045 /* Progress.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A14315981CDBFC3F00C279FD /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14315971CDBFC3F00C279FD /* main.swift */; };
 		A14315A31CDBFEA300C279FD /* RomeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A143159A1CDBFE8600C279FD /* RomeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -46,6 +47,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		054C97801D549B3B00C481BD /* TaskStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TaskStatus.swift; path = Utilities/TaskStatus.swift; sourceTree = "<group>"; };
 		056D13DB1CEF58B2002FF045 /* Progress.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Progress.framework; path = Carthage/Build/Mac/Progress.framework; sourceTree = "<group>"; };
 		A14315871CDBFB9200C279FD /* RomeBuild.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RomeBuild.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A14315911CDBFB9200C279FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 				A14315C21CDE449E00C279FD /* Unzip.swift */,
 				A14315C81CDE7F7800C279FD /* Rome.swift */,
 				A14E81E71CF284550064DF2B /* Helpers.swift */,
+				054C97801D549B3B00C481BD /* TaskStatus.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -227,6 +230,7 @@
 				A14315AD1CDBFEED00C279FD /* HelpCommand.swift in Sources */,
 				A14E81E81CF284550064DF2B /* Helpers.swift in Sources */,
 				A14E81E61CF272020064DF2B /* UploadSelfCommand.swift in Sources */,
+				054C97811D549B3B00C481BD /* TaskStatus.swift in Sources */,
 				A14315C31CDE449E00C279FD /* Unzip.swift in Sources */,
 				A14315C91CDE7F7800C279FD /* Rome.swift in Sources */,
 				A14315BE1CDE2C8A00C279FD /* Carthage.swift in Sources */,

--- a/RomeBuild/Carthage/Carthage.swift
+++ b/RomeBuild/Carthage/Carthage.swift
@@ -1,13 +1,30 @@
 import Foundation
 
-func Carthage(args: [String], path: String? = nil) -> Int32 {
+func Carthage(args: [String], path: String? = nil) -> TaskStatus {
     let task = NSTask()
+    let standardOutputPipe = NSPipe()
     task.launchPath = "/usr/local/bin/carthage"
     if let path = path {
         task.currentDirectoryPath = path
     }
     task.arguments = args
+    task.standardOutput = standardOutputPipe
     task.launch()
     task.waitUntilExit()
-    return task.terminationStatus
+
+    let readHandle = standardOutputPipe.fileHandleForReading
+    let data = readHandle.readDataToEndOfFile()
+    if let standardOutput = String.init(data: data, encoding: NSUTF8StringEncoding) {
+        let lines = standardOutput.characters.split { $0 == "\n" || $0 == "\r\n" }.map(String.init)
+        return TaskStatus(status: task.terminationStatus, standardOutput: lines)
+    } else {
+        return TaskStatus(status: task.terminationStatus, standardOutput: nil)
+    }
+}
+
+func getFrameworkPath(taskStatus: TaskStatus) -> String? {    
+    if let lastLineOfOutput = taskStatus.standardOutput?.last {
+        return Helpers().matchesForRegexInText("Created (.*framework.zip)$", text: lastLineOfOutput)?.first
+    }
+    return nil
 }

--- a/RomeBuild/Carthage/Carthage.swift
+++ b/RomeBuild/Carthage/Carthage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Regex
 
 func Carthage(args: [String], path: String? = nil) -> TaskStatus {
     let task = NSTask()
@@ -24,7 +25,7 @@ func Carthage(args: [String], path: String? = nil) -> TaskStatus {
 
 func getFrameworkPath(taskStatus: TaskStatus) -> String? {    
     if let lastLineOfOutput = taskStatus.standardOutput?.last {
-        return Helpers().matchesForRegexInText("Created (.*framework.zip)$", text: lastLineOfOutput)?.first
+        return Regex("Created (.*framework.zip)$").match(lastLineOfOutput)?.captures[0]
     }
     return nil
 }

--- a/RomeBuild/Commands/UploadCommand.swift
+++ b/RomeBuild/Commands/UploadCommand.swift
@@ -45,7 +45,6 @@ struct UploadCommand {
                 
                 Carthage(buildArchive)
                 let status = Carthage(["archive", "--output", Environment().currentDirectory()!], path: dependencyPath)
-
                 Helpers().uploadAsset(dependency, revision: dependenciesToBuild[dependency]!, filePath: getFrameworkPath(status))
             }
         }

--- a/RomeBuild/Commands/UploadCommand.swift
+++ b/RomeBuild/Commands/UploadCommand.swift
@@ -44,9 +44,9 @@ struct UploadCommand {
                 }
                 
                 Carthage(buildArchive)
-                Carthage(["archive", "--output", Environment().currentDirectory()!], path: dependencyPath)
-                Helpers().uploadAsset(dependency, revision: dependenciesToBuild[dependency]!)
-                
+                let status = Carthage(["archive", "--output", Environment().currentDirectory()!], path: dependencyPath)
+
+                Helpers().uploadAsset(dependency, revision: dependenciesToBuild[dependency]!, filePath: getFrameworkPath(status))
             }
         }
         

--- a/RomeBuild/Commands/UploadSelfCommand.swift
+++ b/RomeBuild/Commands/UploadSelfCommand.swift
@@ -21,9 +21,9 @@ struct UploadSelfCommand {
         }
         
         Carthage(buildArchive)
-        Carthage(["archive"])
+        let status = Carthage(["archive"])
         
-        Helpers().uploadAsset(productName, revision: revision)
+        Helpers().uploadAsset(productName, revision: revision, filePath: getFrameworkPath(status))
         print("Upload complete")
         
     }

--- a/RomeBuild/Utilities/Helpers.swift
+++ b/RomeBuild/Utilities/Helpers.swift
@@ -2,17 +2,36 @@ import Foundation
 
 struct Helpers {
 
-    func uploadAsset(name: String, revision: String) {
-        
+    func uploadAsset(name: String, revision: String, filePath: String? = nil) {
+        var path: String
+        if let filePath = filePath {
+            path = filePath
+        } else {
+            path = "\(Environment().currentDirectory()!)/\(name).framework.zip"
+        }
+
         do
         {
-            let filePath = "\(Environment().currentDirectory()!)/\(name).framework.zip"
-            Rome().addAsset(name, revision: revision, path: filePath)
-            try NSFileManager.defaultManager().removeItemAtPath(filePath)
+            Rome().addAsset(name, revision: revision, path: path)
+            try NSFileManager.defaultManager().removeItemAtPath(path)
         } catch {
             print(error)
         }
         
     }
+
+    func matchesForRegexInText(regex: String!, text: String!) -> [String]? {
+
+        do {
+            let regex = try NSRegularExpression(pattern: regex, options: [])
+            let nsString = text as NSString
+            let results = regex.matchesInString(text,
+                                                options: [], range: NSMakeRange(0, nsString.length))
+            return results.map { nsString.substringWithRange($0.rangeAtIndex(1))}
+        } catch {
+            return nil
+        }
+    }
+
     
 }

--- a/RomeBuild/Utilities/Helpers.swift
+++ b/RomeBuild/Utilities/Helpers.swift
@@ -19,19 +19,4 @@ struct Helpers {
         }
         
     }
-
-    func matchesForRegexInText(regex: String!, text: String!) -> [String]? {
-
-        do {
-            let regex = try NSRegularExpression(pattern: regex, options: [])
-            let nsString = text as NSString
-            let results = regex.matchesInString(text,
-                                                options: [], range: NSMakeRange(0, nsString.length))
-            return results.map { nsString.substringWithRange($0.rangeAtIndex(1))}
-        } catch {
-            return nil
-        }
-    }
-
-    
 }

--- a/RomeBuild/Utilities/TaskStatus.swift
+++ b/RomeBuild/Utilities/TaskStatus.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct TaskStatus {
+    let status: Int32
+    let standardOutput : [String]?
+}


### PR DESCRIPTION
There is an issue where if the framework generated by carthage has a filename different from the repository name, romebuild fails to find the file.

This P.R. uses the standard output generated by Carthage to use the correct filename for the framework.zip
